### PR TITLE
Check that environment variables are provided

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -148,16 +148,18 @@ func setup(c *caddy.Controller) error {
 		if accessToken == "" {
 			// Keep this environment variable name consistent across all our integrations (e.g. SDKs, Terraform provider).
 			accessToken = os.Getenv("DNSIMPLE_TOKEN")
-			if accessToken == "" {
-				return plugin.Error("dnsimple", c.Err("access token must be provided via the Corefile or DNSIMPLE_TOKEN environment variable"))
-			}
+		}
+		// Still blank, return error
+		if accessToken == "" {
+			return plugin.Error("dnsimple", c.Err("access token must be provided via the Corefile or DNSIMPLE_TOKEN environment variable"))
 		}
 
 		if opts.accountId == "" {
 			opts.accountId = os.Getenv("DNSIMPLE_ACCOUNT_ID")
-			if opts.accountId == "" {
-				return plugin.Error("dnsimple", c.Err("account ID must be provided via the Corefile or DNSIMPLE_TOKEN environment variable"))
-			}
+		}
+		// Still blank, return error
+		if opts.accountId == "" {
+			return plugin.Error("dnsimple", c.Err("account ID must be provided via the Corefile or DNSIMPLE_TOKEN environment variable"))
 		}
 
 		if baseUrl == "" {

--- a/setup.go
+++ b/setup.go
@@ -148,10 +148,16 @@ func setup(c *caddy.Controller) error {
 		if accessToken == "" {
 			// Keep this environment variable name consistent across all our integrations (e.g. SDKs, Terraform provider).
 			accessToken = os.Getenv("DNSIMPLE_TOKEN")
+			if accessToken == "" {
+				return plugin.Error("dnsimple", c.Err("access token must be provided via the Corefile or DNSIMPLE_TOKEN environment variable"))
+			}
 		}
 
 		if opts.accountId == "" {
 			opts.accountId = os.Getenv("DNSIMPLE_ACCOUNT_ID")
+			if opts.accountId == "" {
+				return plugin.Error("dnsimple", c.Err("account ID must be provided via the Corefile or DNSIMPLE_TOKEN environment variable"))
+			}
 		}
 
 		if baseUrl == "" {

--- a/setup_test.go
+++ b/setup_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestSetupDNSimple(t *testing.T) {
+	t.Setenv("DNSIMPLE_TOKEN", "token")
+	t.Setenv("DNSIMPLE_ACCOUNT_ID", "12345")
+
 	fakeClient := new(fakeDNSimpleClient)
 	newDnsimpleService = func(ctx context.Context, options Options, accessToken, baseUrl string) (dnsimpleService, error) {
 		return fakeClient, nil


### PR DESCRIPTION
If configuration settings aren't provided via the Corefile, raise an error if they also aren't provided via environment variables.

Fixes #20.