### PR TITLE
Use alternative DNS resolver for initial setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+FEATURES:
+
+- The plugin now supports the setting of `client_dns_resolver` to override the DNS resolver used for DNSimple API endpoints. This is useful when running CoreDNS as the DNS resolver for the host. Format is `ADDRESS:PORT`. (#25)
+
 ## 1.0.0-rc.1
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ dnsimple ZONE[:REGION ZONE ...] {
     account_id            DNSIMPLE_ACCOUNT_ID
     base_url              STRING
     custom_dns_resolver   ADDRESS
+    client_dns_resolver   ADDRESS
     fallthrough           [ZONES...]
     identifier            STRING
     max_retries           MAX_RETRIES
@@ -28,8 +29,9 @@ dnsimple ZONE[:REGION ZONE ...] {
 - `account_id`: The account ID containing the configured zones. If it's not provided, the environment variable `DNSIMPLE_ACCOUNT_ID` will be used.
 - `base_url`: The base url for interacting with the DNSimple API. If no value is provided the production environment is used. See [DNSimple Sandbox API](https://support.dnsimple.com/articles/sandbox/) for sandbox environment testing.
 - `custom_dns_resolver`: Optionally override the DNS resolver to use for resolving ALIAS records. By default, the system resolver is used. See the [ALIAS records](#alias-records) section for more details.
+- `client_dns_resolver`: Optionally provide a DNS resolver to use for resolving DNSimple API endpoints. By default, the system resolver is used. This is useful when running CoreDNS as the DNS resolver for the host. Format is `ADDRESS:PORT`.
 - `fallthrough`: If a query matches the zone(s) but no response message can be generated, the query will be passed to the next plugin in the chain. To restrict passing only for specific zones, list them here; all other zone queries will **not** "fall through".
-- `identifer`: Optionally set the CoreDNS instance identifer string. This is used to report the sync status of the zone to the DNSimple application. If no identifier is provided, "default" is used.
+- `identifier`: Optionally set the CoreDNS instance identifier string. This is used to report the sync status of the zone to the DNSimple application. If no identifier is provided, "default" is used.
 - `max_retries`: Maximum retry attempts to fetch zones using the DNSimple API. Must be greater than zero. Defaults to 3.
 - `refresh`: The interval to refresh zones at. It must be a valid duration, and defaults to `1m`.
 

--- a/dnsimple.go
+++ b/dnsimple.go
@@ -93,7 +93,13 @@ func createDNSimpleAPICaller(options Options, baseURL string, accessToken string
 
 		client := http.Client{}
 		if options.clientDNSResolver != "" {
-			client.Transport.(*http.Transport).DialContext = options.customHTTPDialer
+			if client.Transport != nil {
+				client.Transport.(*http.Transport).DialContext = options.customHTTPDialer
+			} else {
+				transport := http.DefaultTransport.(*http.Transport).Clone()
+				transport.DialContext = options.customHTTPDialer
+				client.Transport = transport
+			}
 		}
 
 		req.Header.Set("authorization", fmt.Sprintf("Bearer %s", accessToken))

--- a/dnsimple.go
+++ b/dnsimple.go
@@ -83,7 +83,7 @@ func (g *nameGraph) insertName(name string, value string) {
 
 type DNSimpleApiCaller func(path string, body []byte) error
 
-func createDNSimpleApiCaller(options Options, baseUrl string, accessToken string, userAgent string) DNSimpleApiCaller {
+func createDNSimpleAPICaller(options Options, baseUrl string, accessToken string, userAgent string) DNSimpleApiCaller {
 	return func(path string, body []byte) error {
 		url := fmt.Sprintf("%s%s", baseUrl, path)
 		req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
@@ -92,8 +92,8 @@ func createDNSimpleApiCaller(options Options, baseUrl string, accessToken string
 		}
 
 		client := http.Client{}
-		if options.clientDnsResolver != "" {
-			client.Transport.(*http.Transport).DialContext = options.customHttpDialer
+		if options.clientDNSResolver != "" {
+			client.Transport.(*http.Transport).DialContext = options.customHTTPDialer
 		}
 
 		req.Header.Set("authorization", fmt.Sprintf("Bearer %s", accessToken))
@@ -166,14 +166,14 @@ func New(ctx context.Context, client dnsimpleService, keys map[string][]string, 
 		}
 	}
 	dnsResolver := net.DefaultResolver
-	if opts.customDnsResolver != "" {
+	if opts.customDNSResolver != "" {
 		dnsResolver = &net.Resolver{
 			PreferGo: true,
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 				d := net.Dialer{
 					Timeout: time.Second * 10,
 				}
-				return d.DialContext(ctx, network, opts.customDnsResolver)
+				return d.DialContext(ctx, network, opts.customDNSResolver)
 			},
 		}
 	}

--- a/dnsimple.go
+++ b/dnsimple.go
@@ -83,9 +83,9 @@ func (g *nameGraph) insertName(name string, value string) {
 
 type DNSimpleApiCaller func(path string, body []byte) error
 
-func createDNSimpleAPICaller(options Options, baseUrl string, accessToken string, userAgent string) DNSimpleApiCaller {
+func createDNSimpleAPICaller(options Options, baseURL string, accessToken string, userAgent string) DNSimpleApiCaller {
 	return func(path string, body []byte) error {
-		url := fmt.Sprintf("%s%s", baseUrl, path)
+		url := fmt.Sprintf("%s%s", baseURL, path)
 		req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dnsimple/dnsimple-go v1.2.0
 	github.com/miekg/dns v1.1.55
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/oauth2 v0.4.0
 )
 
 require (
@@ -30,7 +31,6 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/oauth2 v0.4.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/tools v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.20
 
 require (
 	github.com/coredns/caddy v1.1.1
-	github.com/coredns/coredns v1.10.1
-	github.com/dnsimple/dnsimple-go v1.2.0
-	github.com/miekg/dns v1.1.55
+	github.com/coredns/coredns v1.11.1
+	github.com/dnsimple/dnsimple-go v1.5.1
+	github.com/miekg/dns v1.1.58
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/oauth2 v0.4.0
+	golang.org/x/oauth2 v0.14.0
 )
 
 require (
@@ -17,26 +17,35 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
+	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/pprof v0.0.0-20230509042627-b1315fad0c5a // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/onsi/ginkgo/v2 v2.11.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.39.0 // indirect
-	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/prometheus/client_golang v1.16.0 // indirect
+	github.com/prometheus/client_model v0.4.0 // indirect
+	github.com/prometheus/common v0.44.0 // indirect
+	github.com/prometheus/procfs v0.10.1 // indirect
+	github.com/quic-go/qtls-go1-20 v0.3.1 // indirect
+	github.com/quic-go/quic-go v0.37.4 // indirect
+	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
-	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/sys v0.5.0 // indirect
-	golang.org/x/text v0.7.0 // indirect
-	golang.org/x/tools v0.4.0 // indirect
+	golang.org/x/crypto v0.18.0 // indirect
+	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
+	golang.org/x/mod v0.14.0 // indirect
+	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/tools v0.17.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.53.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230807174057-1744710a1577 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/setup.go
+++ b/setup.go
@@ -50,7 +50,7 @@ var newDnsimpleService = func(ctx context.Context, accessToken string, baseUrl s
 			},
 		},
 	}
-	http.DefaultTransport.(*http.Transport).DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+	httpClient.Transport.(*http.Transport).DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return dialer.DialContext(ctx, network, addr)
 	}
 	client := dnsimple.NewClient(httpClient)

--- a/setup.go
+++ b/setup.go
@@ -54,7 +54,7 @@ var newDnsimpleService = func(ctx context.Context, accessToken string, baseUrl s
 	// `StaticTokenHTTPClient` calls `oauth2.NewClient`
 	// which returns a `http.Client` with the field `Transport`
 	// set to a `oauth2.Transport`, which has a `Base` field
-  // set to `oauth2.internal.ContextClient(...).Transport`
+	// set to `oauth2.internal.ContextClient(...).Transport`
 	// which evaluates to a type equivalent to `http.Client{}.Transport`.
 	httpClient.Transport.(*oauth2.Transport).Base.(*http.Transport).DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return dialer.DialContext(ctx, network, addr)

--- a/setup.go
+++ b/setup.go
@@ -43,7 +43,13 @@ var newDnsimpleService = func(ctx context.Context, options Options, accessToken 
 	httpClient := dnsimple.StaticTokenHTTPClient(ctx, accessToken)
 
 	if options.clientDNSResolver != "" {
-		httpClient.Transport.(*oauth2.Transport).Base.(*http.Transport).DialContext = options.customHTTPDialer
+		if httpClient.Transport.(*oauth2.Transport).Base != nil {
+			httpClient.Transport.(*oauth2.Transport).Base.(*http.Transport).DialContext = options.customHTTPDialer
+		} else {
+			transport := http.DefaultTransport.(*http.Transport).Clone()
+			transport.DialContext = options.customHTTPDialer
+			httpClient.Transport.(*oauth2.Transport).Base = transport
+		}
 	}
 	client := dnsimple.NewClient(httpClient)
 	client.BaseURL = baseUrl

--- a/setup_test.go
+++ b/setup_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSetupDNSimple(t *testing.T) {
 	fakeClient := new(fakeDNSimpleClient)
-	newDnsimpleService = func(ctx context.Context, accessToken, baseUrl string) (dnsimpleService, error) {
+	newDnsimpleService = func(ctx context.Context, options Options, accessToken, baseUrl string) (dnsimpleService, error) {
 		return fakeClient, nil
 	}
 


### PR DESCRIPTION
Use custom DNS resolver for HTTP requests to the DNSimple API during the initial setup phase to ensure they don't fail if the CoreDNS server itself is used as the system resolver, as it won't be ready at that time. Fixes #21 