### PR TITLE
Fix prealloc lint warning in test

### DIFF
--- a/dnsimple_internal_test.go
+++ b/dnsimple_internal_test.go
@@ -467,7 +467,7 @@ func TestDNSimple(t *testing.T) {
 				}
 			}
 		} else {
-			msgAnswers := make([]string, 0)
+			msgAnswers := make([]string, 0, len(rec.Msg.Answer))
 			assert.NotNilf(t, rec.Msg, "Test %d: Unexpected Msg was nil.", ti)
 
 			for _, a := range rec.Msg.Answer {


### PR DESCRIPTION
Fix `prealloc` lint finding by preallocating `msgAnswers` slice with the known capacity from `rec.Msg.Answer`. This was the only lint issue preventing `make release` from succeeding.


## :clipboard: Deployment Pre/Post tasks

N/A


## :shipit: Deployment Verification

- [x] `golangci-lint run` passes with 0 issues
- [x] `go test ./...` passes